### PR TITLE
Use https url for cloning

### DIFF
--- a/lib/zewo.rb
+++ b/lib/zewo.rb
@@ -275,7 +275,7 @@ module Zewo
         print "Checking #{repo.name}..." + "\n"
         unless File.directory?(repo.name)
           print "Cloning #{repo.name}...".green + "\n"
-          silent_cmd("git clone #{repo.data['ssh_url']}")
+          silent_cmd("git clone #{repo.data['clone_url']}")
         end
       end
       puts 'Done!'


### PR DESCRIPTION
Using ssh for cloning is fine but it requires ssh keys to be configured. Why do that when cloning with https doesn't?
