### PR TITLE
[WIP] Rewrite tool to be more stable and have a more narrow feature scope

### DIFF
--- a/lib/zewo.rb
+++ b/lib/zewo.rb
@@ -206,7 +206,7 @@ module Zewo
 
         desc :init, 'Clones all repositories from the topmost repository node.'
         def init
-            top_node = Repo.new('Zewo', 'Flux')
+            top_node = Repo.new('Flux', 'Zewo')
             Repo.repos['Zewo/Flux'] = top_node
 
             top_node.clone_dependencies()

--- a/lib/zewo.rb
+++ b/lib/zewo.rb
@@ -206,8 +206,8 @@ module Zewo
 
         desc :init, 'Clones all repositories from the topmost repository node.'
         def init
-            top_node = Repo.new('Zewo', 'Zewo')
-            Repo.repos['Zewo/Zewo'] = top_node
+            top_node = Repo.new('Zewo', 'Flux')
+            Repo.repos['Zewo/Flux'] = top_node
 
             top_node.clone_dependencies()
             top_node.setup_xcode_projects()

--- a/lib/zewo.rb
+++ b/lib/zewo.rb
@@ -11,207 +11,374 @@ require 'colorize'
 require 'thread'
 require 'thwait'
 
-def silent_cmd(cmd)
-  system("#{cmd} > /dev/null 2>&1")
-end
-
 module Zewo
-    class App < Thor
-        class Repo
-            @@repos = Hash.new()
+  class App < Thor
+    class Repo
+      @@repos = {}
 
-            attr_reader :repo
-            @repo
-            attr_reader :organization
-            @organization
+      @@lock_branches = {'CURIParser' => '0.2.0', 'CHTTPParser' => '0.2.0', 'CLibvenice' => '0.2.0'}
 
-            @xcode_project = nil
-            @configured = false
+      attr_reader :repo
+      @repo
+      attr_reader :organization
+      @organization
 
-            def initialize(repo, organization)
-                @repo = repo
-                @organization = organization
-            end
+      @xcode_project = nil
+      @configured = false
 
-            def clone
-                puts "Cloning #{@organization}/#{@repo}".green
+      def initialize(repo, organization)
+        @repo = repo
+        @organization = organization
+      end
 
-                flags = ''
-                flags = '--branch 0.2.0' if @repo == 'CURIParser' || @repo == 'CHTTPParser' || @repo == 'CLibvenice'
-                `git clone #{flags} https://github.com/#{@organization}/#{@repo} &> /dev/null`
-            end
+      def clone
+        puts "Cloning #{path}".green
 
-            def dependencies
+        flags = ''
 
-                unless File.directory?(@repo)
-                    clone()
-                end
+        if @@lock_branches[@repo]
+          flags = "--branch #{@@lock_branches[@repo]}"
+        end
+        
+        `git clone #{flags} https://github.com/#{@organization}/#{@repo} #{path} &> /dev/null`
+      end
 
-                package_swift_contents = File.read("#{@repo}/Package.swift")
+      def dependencies
+        clone unless File.directory?(path)
 
-                # matches the packages like `VeniceX/Venice`
-                regex = /https:\/\/github.com\/(.*\/*)"/
-                matches = package_swift_contents.scan(regex).map(&:first).map { |e| e = e.chomp('.git') if e.end_with?('.git'); e }
+        package_swift_contents = File.read("#{path}/Package.swift")
 
-                # splits VeniceX/Venice into ['VeniceX', 'Venice']
-                splits = matches.map { |e| e.split('/', 2) }
+        # matches the packages like `VeniceX/Venice`
+        regex = /https:\/\/github.com\/(.*\/*)"/
+        matches = package_swift_contents.scan(regex).map(&:first).map { |e| e = e.chomp('.git') if e.end_with?('.git'); e }
 
-                # creates a Repo using VeniceX as organization and Venice as repo
-                repos = splits.map { |s| Repo.new(s[1], s[0]) }
+        # splits VeniceX/Venice into ['VeniceX', 'Venice']
+        splits = matches.map { |e| e.split('/', 2) }
 
-                cached = repos.map { |m|
-                    # add it to global list of repositories if it isnt already in there
-                    @@repos["#{m.organization}/#{m.repo}"] = m unless @@repos["#{m.organization}/#{m.repo}"]
-                    @@repos["#{m.organization}/#{m.repo}"]
-                }
+        # creates a Repo using VeniceX as organization and Venice as repo
+        repos = splits.map { |s| Repo.new(s[1], s[0]) }
 
-                return cached
-            end
-
-            def clone_dependencies
-                # clone all dependencies that don't exist yet
-                dependencies.each(&:clone_dependencies)
-            end
-
-            def setup_xcode_projects
-                # create xcode project
-                setup_xcode_project()
-
-                # recursively do the same for all dependencies
-                dependencies.each(&:setup_xcode_projects)
-            end
-
-            def configure_xcode_projects
-                # configure xcode project
-                configure_xcode_project()
-
-                # recursively do the same for all dependencies
-                dependencies.each(&:configure_xcode_projects)
-            end
-
-            def setup_xcode_project
-
-                return if @xcode_project
-
-                puts "Creating Xcode project for #{@organization}/#{@repo}".green
-
-                @xcode_project = Xcodeproj::Project.new(xcode_project_path)
-
-                framework_target.build_configurations.each do |configuration|
-                    framework_target.build_settings(configuration.name)['HEADER_SEARCH_PATHS'] = '/usr/local/include'
-                    framework_target.build_settings(configuration.name)['LIBRARY_SEARCH_PATHS'] = '/usr/local/lib'
-                    framework_target.build_settings(configuration.name)['ENABLE_TESTABILITY'] = 'YES'
-
-                    if File.exist?("#{@repo}/module.modulemap")
-                        framework_target.build_settings(configuration.name)['MODULEMAP_FILE'] = '../module.modulemap'
-                    end
-                end
-
-                if sources_path
-                    group = @xcode_project.new_group('Sources')
-                    add_files("#{@repo}/#{sources_path}/*", group, framework_target)
-                end
-
-                test_target.resources_build_phase
-                test_target.add_dependency(framework_target)
-
-                test_target.build_configurations.each do |configuration|
-                    test_target.build_settings(configuration.name)['WRAPPER_EXTENSION'] = 'xctest'
-                    test_target.build_settings(configuration.name)['LD_RUNPATH_SEARCH_PATHS'] = '$(inherited) @executable_path/../../Frameworks @loader_path/../Frameworks'
-                    test_target.build_settings(configuration.name)['HEADER_SEARCH_PATHS'] = '/usr/local/include'
-                    test_target.build_settings(configuration.name)['LIBRARY_SEARCH_PATHS'] = '/usr/local/lib'
-                end
-
-                group = @xcode_project.new_group('Tests')
-                add_files("#{@repo}/Tests/*", group, test_target)
-
-                @xcode_project.save
-
-                scheme = Xcodeproj::XCScheme.new
-                scheme.configure_with_targets(framework_target, test_target)
-                # scheme.test_action.code_coverage_enabled = true
-                scheme.save_as(@xcode_project.path, framework_target.name, true)
-
-                framework_target.frameworks_build_phase.clear
-            end
-
-            def configure_xcode_project
-
-                return if @configured
-
-                puts "Configuring Xcode project for #{@organization}/#{@repo}".green
-
-                group = @xcode_project.new_group('Subprojects')
-
-                dependencies.each do |repo|
-                  next if repo.repo.end_with?('-OSX')
-
-                  project_reference = group.new_file(repo.xcode_project_path.to_s)
-                  project_reference.path = "../../#{project_reference.path}"
-                  framework_target.add_dependency(repo.framework_target) if framework_target
-                end
-                @xcode_project.save
-                @configured = true
-            end
-
-            def add_files(direc, current_group, main_target)
-                Dir.glob(direc) do |item|
-                    next if item == '.' || item == '.DS_Store'
-
-                    if File.directory?(item)
-                        new_folder = File.basename(item)
-                        created_group = current_group.new_group(new_folder)
-                        add_files("#{item}/*", created_group, main_target)
-                    else
-                        item = item.split('/')[1..-1].unshift('..') * '/'
-                        i = current_group.new_file(item)
-                        main_target.add_file_references([i]) if item.include? '.swift'
-                    end
-                end
-            end
-
-            def xcode_project_path
-                return "#{@repo}/XcodeDevelopment/#{@repo}.xcodeproj"
-            end
-
-            def sources_path
-                return 'Sources' if File.directory?("#{@repo}/Sources")
-                return 'Source'  if File.directory?("#{@repo}/Source")
-            end
-
-            def framework_target
-                target_name = repo.gsub('-OSX', '').gsub('-', '_')
-                target_name = 'OperatingSystem' if target_name == 'OS'
-                @xcode_project.native_targets.find { |t| t.name == target_name } || @xcode_project.new_target(:framework, target_name, :osx)
-            end
-
-            def test_target
-                target_name = "#{framework_target.name}-Test"
-                @xcode_project.native_targets.find { |t| t.name == target_name } || @xcode_project.new_target(:bundle, target_name, :osx)
-            end
-
-            # getter/setter for class variable
-            def Repo::repos
-                @@repos
-            end
-
-            def Repo::repos= (value)
-                puts @@repos
-                @@repos = value
-            end
+        cached = repos.map do |m|
+          # add it to global list of repositories if it isnt already in there
+          @@repos["#{m.organization}/#{m.repo}"] = m unless @@repos["#{m.organization}/#{m.repo}"]
+          @@repos["#{m.organization}/#{m.repo}"]
         end
 
-        no_commands do
+        cached
+      end
+
+      def clone_dependencies
+        # clone all dependencies that don't exist yet
+        dependencies.each(&:clone_dependencies)
+      end
+
+      def setup_xcode_projects
+        # create xcode project
+        setup_xcode_project
+
+        # recursively do the same for all dependencies
+        dependencies.each(&:setup_xcode_projects)
+      end
+
+      def configure_xcode_projects
+        # configure xcode project
+        configure_xcode_project
+
+        # recursively do the same for all dependencies
+        dependencies.each(&:configure_xcode_projects)
+      end
+
+      def flat_dependencies
+        result = dependencies
+
+        dependencies.each do |dep|
+          result += dep.flat_dependencies
         end
 
-        desc :init, 'Clones all repositories from the topmost repository node.'
-        def init
-            top_node = Repo.new('Flux', 'Zewo')
-            Repo.repos['Zewo/Flux'] = top_node
+        result.uniq
+      end
 
-            top_node.clone_dependencies()
-            top_node.setup_xcode_projects()
-            top_node.configure_xcode_projects()
+
+      def headers
+        @headers ||= Dir.glob("#{path}/*.h")
+      end
+
+      def setup_xcode_project
+        return if @xcode_project
+
+        puts "Creating Xcode project for #{@organization}/#{@repo}".green
+
+        @xcode_project = Xcodeproj::Project.new("#{xcode_project_path}")
+        @xcode_project.initialize_from_scratch
+
+        framework_target.build_configurations.each do |configuration|
+          framework_target.build_settings(configuration.name)['HEADER_SEARCH_PATHS'] = '/usr/local/include'
+          framework_target.build_settings(configuration.name)['LIBRARY_SEARCH_PATHS'] = '/usr/local/lib'
+          framework_target.build_settings(configuration.name)['ENABLE_TESTABILITY'] = 'YES'
+
+          if File.exist?("#{path}/module.modulemap")
+            framework_target.build_settings(configuration.name)['MODULEMAP_FILE'] = '../module.modulemap'
+          end
         end
+
+        if sources_path
+          group = @xcode_project.new_group('Sources')
+          add_files("#{path}/#{sources_path}/*", group, framework_target)
+        end
+
+        test_target.resources_build_phase
+        test_target.add_dependency(framework_target)
+
+        test_target.build_configurations.each do |configuration|
+          test_target.build_settings(configuration.name)['WRAPPER_EXTENSION'] = 'xctest'
+          test_target.build_settings(configuration.name)['LD_RUNPATH_SEARCH_PATHS'] = '$(inherited) @executable_path/../../Frameworks @loader_path/../Frameworks'
+          test_target.build_settings(configuration.name)['HEADER_SEARCH_PATHS'] = '/usr/local/include'
+          test_target.build_settings(configuration.name)['LIBRARY_SEARCH_PATHS'] = '/usr/local/lib'
+        end
+
+        group = @xcode_project.new_group('Tests')
+        add_files("#{path}/Tests/*", group, test_target)
+
+        @xcode_project.save
+
+        scheme = Xcodeproj::XCScheme.new
+        scheme.configure_with_targets(framework_target, test_target)
+        # scheme.test_action.code_coverage_enabled = true
+        scheme.save_as(@xcode_project.path, framework_target.name, true)
+
+        framework_target.frameworks_build_phase.clear
+      end
+
+      def configure_xcode_project
+        return if @configured
+
+        puts "Configuring Xcode project for #{path}".green
+
+        group = @xcode_project.new_group('Subprojects')
+
+        # This next block will move through the flattened dependencies of a project
+        # to determine whether any of them have headers associated with their module maps.
+        # If they do, each header must be added to the header search paths configuration
+        flat_dependencies.select { |d| d.headers.count > 0 }.each do |header_dep|
+          header_search_path = "../../../#{header_dep.path}"
+
+          [framework_target, test_target].each do |target|
+            target.build_configurations.each do |configuration|
+              existing = target.build_settings(configuration.name)['HEADER_SEARCH_PATHS']
+              unless existing.include? header_search_path
+                existing += " #{header_search_path}"
+                target.build_settings(configuration.name)['HEADER_SEARCH_PATHS'] = existing
+              end
+            end
+          end
+        end
+
+        dependencies.each do |repo|
+          next if repo.repo.end_with?('-OSX')
+
+          project_reference = group.new_file(repo.xcode_project_path.to_s)
+          project_reference.path = "../../../#{project_reference.path}"
+          framework_target.add_dependency(repo.framework_target) if framework_target
+        end
+        @xcode_project.save
+        @configured = true
+      end
+
+      def add_files(direc, current_group, main_target)
+        Dir.glob(direc) do |item|
+          next if item.start_with?('.')
+
+          if File.directory?(item)
+            new_folder = File.basename(item)
+            created_group = current_group.new_group(new_folder)
+            add_files("#{item}/*", created_group, main_target)
+          else
+            # Basically means "Remove Zewo from path and prepend '../'"
+            item = item.split('/')[1..-1].unshift('..', '..') * '/'
+            i = current_group.new_file(item)
+            main_target.add_file_references([i]) if item.include? '.swift'
+          end
+        end
+      end
+
+      def xcode_project_path
+        "#{path}/XcodeDevelopment/#{@repo}.xcodeproj"
+      end
+
+      def path
+        "#{@organization}/#{@repo}"
+      end
+
+      def status
+        `cd #{path}; git status`
+      end
+
+      def call(str)
+        output = `cd #{path}; #{str} 2>&1`.chomp
+        raise output unless $?.success?
+        output
+      end
+
+      def uncommited_changes?
+        begin
+          call('git diff --quiet HEAD')
+          return false
+        rescue
+          return true
+        end
+      end
+
+      def master_branch?
+        call('git rev-parse --abbrev-ref HEAD')
+      end
+
+      def tag
+        return call('git describe --abbrev=0 --tags')
+      rescue
+        return 'No tags'
+      end
+
+      def branch
+        call('git rev-parse --abbrev-ref HEAD')
+      end
+
+      def pull
+        call('git pull')
+      end
+
+      def sources_path
+        return 'Sources' if File.directory?("#{path}/Sources")
+        return 'Source'  if File.directory?("#{path}/Source")
+      end
+
+      def framework_target
+        target_name = repo.gsub('-OSX', '').gsub('-', '_')
+        target_name = 'OperatingSystem' if target_name == 'OS'
+        @xcode_project.native_targets.find { |t| t.name == target_name } || @xcode_project.new_target(:framework, target_name, :osx)
+      end
+
+      def test_target
+        target_name = "#{framework_target.name}-Test"
+        @xcode_project.native_targets.find { |t| t.name == target_name } || @xcode_project.new_target(:bundle, target_name, :osx)
+      end
+
+      def tag_lock
+        @tag_lock ||= @@lock_branches[@repo]
+      end
+
+      def self::lock_branches
+        @@lock_branches
+      end
+
+      # getter/setter for class variable
+      def self::repos
+        @@repos
+      end
+
+      def self::repos=(value)
+        puts @@repos
+        @@repos = value
+      end
     end
+
+    no_commands do
+      def each_repo(include_lock_branches = true)
+        Repo.repos.each_pair do |key, repo|
+          next if !include_lock_branches && Repo::lock_branches.has_key?(repo.repo)
+          yield key, repo
+        end
+      end
+
+      def each_repo_async(include_lock_branches = true)
+        threads = []
+        Repo.repos.each_pair do |key, repo|
+          next if !include_lock_branches && Repo::lock_branches.has_key?(repo.repo)
+          threads << Thread.new do
+            yield(key, repo)
+          end
+        end
+        threads.each { |thr| thr.join }
+      end
+
+      def create_dotfile
+        FileUtils.touch('.zewodev')
+      end
+
+      def has_dotfile
+        File.exist?('.zewodev')
+      end
+     
+    end
+
+    attr_reader :top_node
+
+    def initialize(*args)
+      super
+      @top_node = Repo.new('Flux', 'Zewo')
+      Repo.repos['Zewo/Flux'] = @top_node
+
+      command_name = nil
+
+      args.each do |a|
+        next unless a.is_a? Hash
+
+        if a.key? :current_command
+          command_name = a[:current_command].name
+          break
+        end
+      end
+
+      if !command_name.nil? && command_name.to_sym != :init
+        unless has_dotfile
+          puts 'zewodev has not been initialized in this directory. Run `zewodev init` do to so.'.red
+          exit
+        end
+      end
+
+      top_node.clone_dependencies
+    end
+
+    desc :init, 'Initializes the current directory as a Zewo development directory'
+    def init
+      create_dotfile
+      invoke :rebuild_projects
+    end
+
+    desc :rebuild_projects, 'Rebuilds Xcode projects'
+    def rebuild_projects
+      top_node.setup_xcode_projects
+      top_node.configure_xcode_projects
+    end
+
+    desc :status, 'Checks status of all repositories'
+    def status
+      each_repo do |key, repo|
+        str = key
+        branch = repo.branch
+        str += " (#{repo.tag}) - #{repo.uncommited_changes? ? branch.red : branch.green}"
+
+        if repo.tag_lock
+          str += " Locked to #{repo.tag_lock}".yellow
+        end
+
+        puts str
+      end
+    end
+
+    desc :pull, 'Pulls recent changes from all repositories'
+    def pull
+      puts "Pulling changes for all repositories..."
+      each_repo_async(false) do |key, repo|
+        begin
+          output = repo.pull
+          str = "#{key}:\n".green
+          str += output
+          str += "\n\n"
+          puts str
+        rescue Exception => e
+          puts "#{key}: #{e.message.red}"
+        end
+      end
+    end
+  end
 end

--- a/lib/zewo.rb
+++ b/lib/zewo.rb
@@ -16,454 +16,197 @@ def silent_cmd(cmd)
 end
 
 module Zewo
-  class App < Thor
-    class Repo
-      attr_reader :name
-      @name = nil
-      attr_reader :data
-      @data = nil
+    class App < Thor
+        class Repo
+            @@repos = Hash.new()
 
-      @xcodeproj = nil
+            attr_reader :repo
+            @repo
+            attr_reader :organization
+            @organization
 
-      def initialize(name, data = nil)
-        @name = name
-        @data = data
-      end
+            @xcode_project = nil
+            @configured = false
 
-      def framework_target
-        target_name = name.gsub('-OSX', '').gsub('-', '_')
-
-        if target_name == 'OS'
-          target_name = 'OperatingSystem'
-        end
-        xcode_project.native_targets.find { |t| t.name == target_name } || xcode_project.new_target(:framework, target_name, :osx)
-      end
-
-      def test_target
-        target_name = "#{framework_target.name}-Test"
-        xcode_project.native_targets.find { |t| t.name == target_name } || xcode_project.new_target(:bundle, target_name, :osx)
-      end
-
-      def dir(ext = nil)
-        r = name
-        r = "#{r}/#{ext}" if ext
-        r
-      end
-
-      def tests_dirname
-        'Tests'
-      end
-
-      def xcode_dirname
-        'XcodeDevelopment'
-      end
-
-      def xcode_project_path
-        dir("#{xcode_dirname}/#{name}.xcodeproj")
-      end
-
-      def sources_dirname
-        return 'Sources' if File.directory?(dir('Sources'))
-        return 'Source'  if File.directory?(dir('Source'))
-      end
-
-      def xcode_project
-        return @xcodeproj if @xcodeproj
-        if File.exist?(xcode_project_path)
-          @xcodeproj = Xcodeproj::Project.open(xcode_project_path)
-        else
-          @xcodeproj = Xcodeproj::Project.new(xcode_project_path)
-        end
-        @xcodeproj
-      end
-
-      def add_files(direc, current_group, main_target)
-        Dir.glob(direc) do |item|
-          next if item == '.' || item == '.DS_Store'
-
-          if File.directory?(item)
-            new_folder = File.basename(item)
-            created_group = current_group.new_group(new_folder)
-            add_files("#{item}/*", created_group, main_target)
-          else
-            item = item.split('/')[1..-1].unshift('..') * '/'
-            i = current_group.new_file(item)
-            main_target.add_file_references([i]) if item.include? '.swift'
-          end
-        end
-      end
-
-      def build_dependencies
-        puts "Configuring dependencies for #{name}".green
-        dependency_repos = File.read(dir('Package.swift')).scan(/(?<=Zewo\/|SwiftX\/|VeniceX\/|paulofaria\/)(.*?)(?=\.git)/).map(&:first)
-        group = xcode_project.new_group('Subprojects')
-        dependency_repos.each do |repo_name|
-          next if repo_name.end_with?('-OSX')
-
-          repo = Repo.new(repo_name)
-          project_reference = group.new_file(repo.xcode_project_path.to_s)
-          project_reference.path = "../../#{project_reference.path}"
-          framework_target.add_dependency(repo.framework_target) if framework_target
-        end
-        xcode_project.save
-      end
-
-      def configure_xcode_project
-        @xcodeproj = nil
-        silent_cmd("rm -rf #{dir(xcode_dirname)}")
-
-        puts "Creating Xcode project #{name}".green
-
-        framework_target.build_configurations.each do |configuration|
-          framework_target.build_settings(configuration.name)['HEADER_SEARCH_PATHS'] = '/usr/local/include'
-          framework_target.build_settings(configuration.name)['LIBRARY_SEARCH_PATHS'] = '/usr/local/lib'
-          framework_target.build_settings(configuration.name)['ENABLE_TESTABILITY'] = 'YES'
-
-          if File.exist?(dir('module.modulemap'))
-            framework_target.build_settings(configuration.name)['MODULEMAP_FILE'] = '../module.modulemap'
-          end
-        end
-
-        framework_target.frameworks_build_phase.clear
-
-        xcode_project.new_file('../module.modulemap') if File.exist?(dir('module.modulemap'))
-
-        if sources_dirname
-          group = xcode_project.new_group(sources_dirname)
-          add_files(dir("#{sources_dirname}/*"), group, framework_target)
-        end
-
-        test_target.resources_build_phase
-        test_target.add_dependency(framework_target)
-
-        test_target.build_configurations.each do |configuration|
-          test_target.build_settings(configuration.name)['WRAPPER_EXTENSION'] = 'xctest'
-          test_target.build_settings(configuration.name)['LD_RUNPATH_SEARCH_PATHS'] = '$(inherited) @executable_path/../../Frameworks @loader_path/../Frameworks'
-          test_target.build_settings(configuration.name)['HEADER_SEARCH_PATHS'] = '/usr/local/include'
-          test_target.build_settings(configuration.name)['LIBRARY_SEARCH_PATHS'] = '/usr/local/lib'
-        end
-
-        group = xcode_project.new_group(tests_dirname)
-        add_files(dir("#{tests_dirname}/*"), group, test_target)
-
-        xcode_project.save
-
-        scheme = Xcodeproj::XCScheme.new
-        scheme.configure_with_targets(framework_target, test_target)
-        scheme.test_action.code_coverage_enabled = true
-        scheme.save_as(xcode_project.path, framework_target.name, true)
-      end
-    end
-
-    no_commands do
-      def each_repo
-        uris = [
-          URI.parse('https://api.github.com/orgs/Zewo/repos?per_page=200'),
-          URI.parse('https://api.github.com/orgs/open-swift/repos?per_page=200')
-        ]
-
-        uris.each do |uri|
-          http = Net::HTTP.new(uri.host, uri.port)
-          http.use_ssl = true
-          request = Net::HTTP::Get.new(uri.request_uri)
-
-          blacklist = ['ZeroMQ']
-
-          response = http.request(request)
-          if response.code == '200'
-            result = JSON.parse(response.body).sort_by { |hsh| hsh['name'] }
-
-            result.each do |doc|
-              next if blacklist.include?(doc['name'])
-              repo = Repo.new(doc['name'], doc)
-              yield repo
+            def initialize(repo, organization)
+                @repo = repo
+                @organization = organization
             end
-          else
-            puts 'Error loading repositories'.red
-          end
+
+            def clone
+                puts "Cloning #{@organization}/#{@repo}".green
+                `git clone https://github.com/#{@organization}/#{@repo} &> /dev/null`
+            end
+
+            def dependencies
+
+                unless File.directory?(@repo)
+                    clone()
+                end
+
+                package_swift_contents = File.read("#{@repo}/Package.swift")
+
+                # matches the packages like `VeniceX/Venice`
+                regex = /https:\/\/github.com\/(.*\/*)"/
+                matches = package_swift_contents.scan(regex).map(&:first).map { |e| e = e.chomp('.git') if e.end_with?('.git'); e }
+
+                # splits VeniceX/Venice into ['VeniceX', 'Venice']
+                splits = matches.map { |e| e.split('/', 2) }
+
+                # creates a Repo using VeniceX as organization and Venice as repo
+                repos = splits.map { |s| Repo.new(s[1], s[0]) }
+
+                cached = repos.map { |m|
+                    # add it to global list of repositories if it isnt already in there
+                    @@repos["#{m.organization}/#{m.repo}"] = m unless @@repos["#{m.organization}/#{m.repo}"]
+                    @@repos["#{m.organization}/#{m.repo}"]
+                }
+
+                return cached
+            end
+
+            def clone_dependencies
+                # clone all dependencies that don't exist yet
+                dependencies.each(&:clone_dependencies)
+            end
+
+            def setup_xcode_projects
+                # create xcode project
+                setup_xcode_project()
+
+                # recursively do the same for all dependencies
+                dependencies.each(&:setup_xcode_projects)
+            end
+
+            def configure_xcode_projects
+                # configure xcode project
+                configure_xcode_project()
+
+                # recursively do the same for all dependencies
+                dependencies.each(&:configure_xcode_projects)
+            end
+
+            def setup_xcode_project
+
+                return if @xcode_project
+
+                puts "Creating Xcode project for #{@organization}/#{@repo}".green
+
+                @xcode_project = Xcodeproj::Project.new(xcode_project_path)
+
+                framework_target.build_configurations.each do |configuration|
+                    framework_target.build_settings(configuration.name)['HEADER_SEARCH_PATHS'] = '/usr/local/include'
+                    framework_target.build_settings(configuration.name)['LIBRARY_SEARCH_PATHS'] = '/usr/local/lib'
+                    framework_target.build_settings(configuration.name)['ENABLE_TESTABILITY'] = 'YES'
+
+                    if File.exist?("#{@repo}/module.modulemap")
+                        framework_target.build_settings(configuration.name)['MODULEMAP_FILE'] = '../module.modulemap'
+                    end
+                end
+
+                if sources_path
+                    group = @xcode_project.new_group('Sources')
+                    add_files("#{@repo}/#{sources_path}/*", group, framework_target)
+                end
+
+                test_target.resources_build_phase
+                test_target.add_dependency(framework_target)
+
+                test_target.build_configurations.each do |configuration|
+                    test_target.build_settings(configuration.name)['WRAPPER_EXTENSION'] = 'xctest'
+                    test_target.build_settings(configuration.name)['LD_RUNPATH_SEARCH_PATHS'] = '$(inherited) @executable_path/../../Frameworks @loader_path/../Frameworks'
+                    test_target.build_settings(configuration.name)['HEADER_SEARCH_PATHS'] = '/usr/local/include'
+                    test_target.build_settings(configuration.name)['LIBRARY_SEARCH_PATHS'] = '/usr/local/lib'
+                end
+
+                group = @xcode_project.new_group('Tests')
+                add_files("#{@repo}/Tests/*", group, test_target)
+
+                @xcode_project.save
+
+                scheme = Xcodeproj::XCScheme.new
+                scheme.configure_with_targets(framework_target, test_target)
+                # scheme.test_action.code_coverage_enabled = true
+                scheme.save_as(@xcode_project.path, framework_target.name, true)
+
+                framework_target.frameworks_build_phase.clear
+            end
+
+            def configure_xcode_project
+
+                return if @configured
+
+                puts "Configuring Xcode project for #{@organization}/#{@repo}".green
+
+                group = @xcode_project.new_group('Subprojects')
+
+                dependencies.each do |repo|
+                  next if repo.repo.end_with?('-OSX')
+
+                  project_reference = group.new_file(repo.xcode_project_path.to_s)
+                  project_reference.path = "../../#{project_reference.path}"
+                  framework_target.add_dependency(repo.framework_target) if framework_target
+                end
+                @xcode_project.save
+                @configured = true
+            end
+
+            def add_files(direc, current_group, main_target)
+                Dir.glob(direc) do |item|
+                    next if item == '.' || item == '.DS_Store'
+
+                    if File.directory?(item)
+                        new_folder = File.basename(item)
+                        created_group = current_group.new_group(new_folder)
+                        add_files("#{item}/*", created_group, main_target)
+                    else
+                        item = item.split('/')[1..-1].unshift('..') * '/'
+                        i = current_group.new_file(item)
+                        main_target.add_file_references([i]) if item.include? '.swift'
+                    end
+                end
+            end
+
+            def xcode_project_path
+                return "#{@repo}/XcodeDevelopment/#{@repo}.xcodeproj"
+            end
+
+            def sources_path
+                return 'Sources' if File.directory?("#{@repo}/Sources")
+                return 'Source'  if File.directory?("#{@repo}/Source")
+            end
+
+            def framework_target
+                target_name = repo.gsub('-OSX', '').gsub('-', '_')
+                @xcode_project.native_targets.find { |t| t.name == target_name } || @xcode_project.new_target(:framework, target_name, :osx)
+            end
+
+            def test_target
+                target_name = "#{framework_target.name}-Test"
+                @xcode_project.native_targets.find { |t| t.name == target_name } || @xcode_project.new_target(:bundle, target_name, :osx)
+            end
+
+            # getter/setter for class variable
+            def Repo::repos
+              @@repos
+            end
+
+            def Repo::repos= (value)
+              @@repos = value
+            end
         end
-      end
 
-      def each_repo_async
-        threads = []
-        each_repo do |repo|
-          threads << Thread.new do
-            yield(repo)
-          end
+        no_commands do
         end
-        ThreadsWait.all_waits(*threads)
-      end
 
-      def each_code_repo
-        each_repo do |repo|
-          next unless File.exist?(repo.dir('Package.swift'))
-          yield repo
+        desc :init, 'Clones all repositories from the topmost repository node.'
+        def init
+            top_node = Repo.new('Zewo', 'Zewo')
+            Repo.repos['Zewo/Zewo'] = top_node
+
+            top_node.clone_dependencies()
+            top_node.setup_xcode_projects()
+            top_node.configure_xcode_projects()
         end
-      end
-
-      def each_code_repo_async
-        threads = []
-        each_code_repo do |repo|
-          threads << Thread.new do
-            yield(repo)
-          end
-        end
-        ThreadsWait.all_waits(*threads)
-      end
-
-      def verify_branches
-        last_branch_name = nil
-        each_repo do |repo|
-          branch_name = `cd #{repo.dir}; git rev-parse --abbrev-ref HEAD`.delete("\n")
-          if !last_branch_name.nil? && branch_name != last_branch_name
-            puts "Branch mismatch. Branch of #{repo.name} does not match previous branch #{branch_name}".red
-            return false
-          end
-          last_branch_name = branch_name
-        end
-        true
-      end
-
-      def prompt(question)
-        printf "#{question} -  y/N: "
-        p = STDIN.gets.chomp
-        p == 'y'
-      end
-
-      def uncommited_changes?(repo_name)
-        !system("cd #{repo_name}; git diff --quiet HEAD")
-      end
-
-      def master_branch?(repo_name)
-        `cd #{repo_name}; git rev-parse --abbrev-ref HEAD`
-      end
-
-      def each_osx_whitelisted_repo
-        Zewo::OSX_CODE_REPO_WHITELIST.each do |repo_name|
-
-          name = repo_name.split('/').last
-          if name.end_with?('-OSX')
-            name = name[0...-4]
-          end
-
-          # rename OS and OperatingSystem to System - workaround
-          if name == 'OS' || name == 'OperatingSystem' && File.directory?('System')
-            name = 'System'
-          end
-
-          repo_data = Hash[
-            'name', name,
-            'organization', repo_name.split('/').first,
-            'clone_url', "https://github.com/#{repo_name}"
-          ]
-
-          yield Repo.new(repo_data['name'], repo_data)
-        end
-      end
-
-      def each_osx_whitelisted_repo_async
-        threads = []
-        each_osx_whitelisted_repo do |repo|
-          threads << Thread.new do
-            yield(repo)
-          end
-        end
-        ThreadsWait.all_waits(*threads)
-      end
-
-      def checkout_modulemap_versions
-        repos = ['CLibvenice', 'CURIParser', 'CHTTPParser']
-        repos.each do |repo|
-          silent_cmd("cd #{repo} && git checkout 0.2.0")
-          puts "Checked out #{repo} at 0.2.0".green
-        end
-      end
     end
-
-    desc :status, 'Get status of all repos'
-    def status
-      each_code_repo do |repo|
-        str = repo.name
-        str = uncommited_changes?(repo.name) ? str.red : str.green
-        tag = `cd #{repo.name}; git describe --abbrev=0 --tags` || 'No tag'
-        str += " (#{tag})"
-        puts str.delete("\n")
-      end
-    end
-
-    desc :tag, 'Tags all code repositories with the given tag. Asks to confirm for each repository'
-    def tag(tag)
-      each_code_repo do |repo|
-        should_tag = prompt("create tag #{tag} in #{repo.name}?")
-        if should_tag
-          silent_cmd("cd #{repo.name} && git tag #{tag}")
-          puts repo.name.green
-        end
-      end
-    end
-
-    desc :checkout, 'Checks out all code repositories to the latest patch release for the given tag/branch'
-    option :branch
-    option :tag
-    def checkout
-      if !options[:branch] && !options[:tag]
-        puts 'Need to specify either --tag or --branch'.red
-        return
-      end
-
-      Dir['*/'].each do |folder_name|
-        folder_name = folder_name[0...-1]
-        matched = `cd #{folder_name} && git tag`
-                  .split("\n")
-                  .select { |t| t.start_with?(options[:tag]) }
-                  .last if options[:tag]
-        matched = options[:branch] if options[:branch]
-
-        if matched
-          silent_cmd("cd #{folder_name} && git checkout #{matched}")
-          puts "Checked out #{folder_name} at #{matched}".green
-        else
-          puts "No matching specifiers for #{folder_name}".red
-        end
-      end
-    end
-
-    desc :pull, 'git pull on all repos'
-    def pull
-      print "Updating all repositories...\n"
-      each_code_repo_async do |repo|
-        if uncommited_changes?(repo.name)
-          print "Uncommitted changes in #{repo.name}. Not updating.".red + "\n"
-          next
-        end
-        system("cd #{repo.name}; git pull")
-      end
-      puts 'Done!'
-    end
-
-    desc :make_projects, 'Makes Xcode projects for all modules'
-    def make_projects
-      each_code_repo(&:configure_xcode_project)
-      each_code_repo(&:build_dependencies)
-    end
-
-    desc :init, 'Clones all Zewo repositories'
-    def init
-      use_ssh = prompt('Clone using SSH?')
-
-      each_repo_async do |repo|
-        print "Checking #{repo.name}..." + "\n"
-        unless File.directory?(repo.name)
-          print "Cloning #{repo.name}...".green + "\n"
-          silent_cmd("git clone #{repo.data[use_ssh ? 'clone_url' : 'ssh_url']}")
-        end
-      end
-      puts 'Done!'
-    end
-
-    desc :clone_osx_dev, 'Clones repositories for OSX development'
-    def clone_osx_dev
-      puts 'Cloning repositories...'
-      each_osx_whitelisted_repo_async do |repo|
-        unless File.directory?(repo.name)
-          print "Cloning #{repo.data['organization']}/#{repo.name}...".green + "\n"
-          silent_cmd("git clone #{repo.data['clone_url']}")
-
-          cloned_name = repo.data['clone_url'].split('/').last
-          if cloned_name.end_with?('-OSX')
-            FileUtils.mv cloned_name, cloned_name[0...-4]
-          end
-        end
-      end
-    end
-
-    desc :make_osx_dev_projects, 'Makes Xcode projects for OSX development repositories'
-    def make_osx_dev_projects
-      each_osx_whitelisted_repo(&:configure_xcode_project)
-      each_osx_whitelisted_repo(&:build_dependencies)
-    end
-
-    desc :setup_osx_dev, 'Sets up OSX development environment (clone, checkout, create xcode projects)'
-    option :version, :required => true
-    def setup_osx_dev()
-      clone_osx_dev()
-
-      if options[:version] == '0.3'
-        `mv OS System`
-      end
-
-      invoke 'checkout', [], :tag => options[:version]
-
-      checkout_modulemap_versions()
-
-      make_osx_dev_projects()
-    end
-  end
-
-  OSX_CODE_REPO_WHITELIST = [
-
-    # Zewo stuff
-    'zewo/Base64',
-    'zewo/BasicAuthMiddleware',
-    'zewo/ContentNegotiationMiddleware',
-    'zewo/Data',
-    'zewo/Event',
-    'zewo/HTTP',
-    'zewo/HTTPJSON',
-    'zewo/HTTPParser',
-    'zewo/HTTPSerializer',
-    'zewo/InterchangeData',
-    'zewo/JSON',
-    'zewo/JSONMediaType',
-    'zewo/Log',
-    'zewo/LogMiddleware',
-    'zewo/MediaType',
-    'zewo/Mustache',
-    'zewo/MySQL',
-    'zewo/OS',
-    'zewo/OpenSSL', 'paulofaria/stream', #just for OpenSSL
-    'zewo/POSIXRegex',
-    'zewo/PathParameterMiddleware',
-    'zewo/PostgreSQL',
-    'zewo/RecoveryMiddleware',
-    'zewo/RegexRouteMatcher',
-    'zewo/Router',
-    'zewo/SQL',
-    'zewo/Sideburns',
-    'zewo/String',
-    'zewo/TrieRouteMatcher',
-    'zewo/URI',
-    'zewo/URLEncodedForm',
-    'zewo/URLEncodedFormMediaType',
-    'zewo/WebSocket',
-    'zewo/ZeroMQ',
-    'zewo/Zewo',
-
-    # C stuff
-    'zewo/CHTTPParser',
-    'zewo/CLibpq-OSX',
-    'zewo/CMySQL-OSX',
-    'zewo/COpenSSL-OSX',
-    'zewo/CURIParser',
-    'zewo/CZeroMQ',
-
-    # VeniceX stuff
-    'venicex/CLibvenice',
-    'venicex/Venice',
-    'venicex/IP',
-    'venicex/TCP',
-    'venicex/UDP',
-    'venicex/HTTPServer',
-    'venicex/HTTPClient',
-    'venicex/TCPSSL',
-    'venicex/HTTPSServer',
-    'venicex/HTTPSClient',
-    'venicex/File',
-    'venicex/HTTPFile',
-    'venicex/ChannelStream',
-
-    # SwiftX stuff
-    'swiftx/S4',
-    'swiftx/C7'
-  ]
 end

--- a/lib/zewo.rb
+++ b/lib/zewo.rb
@@ -35,7 +35,10 @@ module Zewo
 
             def clone
                 puts "Cloning #{@organization}/#{@repo}".green
-                `git clone https://github.com/#{@organization}/#{@repo} &> /dev/null`
+
+                flags = ''
+                flags = '--branch 0.2.0' if @repo == 'CURIParser' || @repo == 'CHTTPParser' || @repo == 'CLibvenice'
+                `git clone #{flags} https://github.com/#{@organization}/#{@repo} &> /dev/null`
             end
 
             def dependencies
@@ -178,6 +181,7 @@ module Zewo
 
             def framework_target
                 target_name = repo.gsub('-OSX', '').gsub('-', '_')
+                target_name = 'OperatingSystem' if target_name == 'OS'
                 @xcode_project.native_targets.find { |t| t.name == target_name } || @xcode_project.new_target(:framework, target_name, :osx)
             end
 
@@ -188,11 +192,12 @@ module Zewo
 
             # getter/setter for class variable
             def Repo::repos
-              @@repos
+                @@repos
             end
 
             def Repo::repos= (value)
-              @@repos = value
+                puts @@repos
+                @@repos = value
             end
         end
 

--- a/lib/zewo/version.rb
+++ b/lib/zewo/version.rb
@@ -1,3 +1,3 @@
 module Zewo
-  VERSION = "0.2.13".freeze
+  VERSION = "0.2.14".freeze
 end


### PR DESCRIPTION
Removes all commands other than simply `zewodev init`, which
- uses a top base node for the dependency hierarchy (Zewo/Flux, it looks like)
- clones top node, then clones all of its dependencies (recursively)
- creates an Xcode project and framework target, then creates it for all of its dependencies (recursively)
- add each dependency as a subproject (recursively)

Stuff left to do:
- [ ] Make Zewo/Flux the topmost node and ensure that it works
- [ ] Allow customization of topmost node 
- [ ] Split command into 3 sub commands, so that they can be used independently
- [ ] Test on multiple machines to make sure that it actually works
